### PR TITLE
remove old bmap viewer

### DIFF
--- a/published-plugins.json
+++ b/published-plugins.json
@@ -61,21 +61,6 @@
           "voutPreview": ""
       },
       {
-          "id": "l88115ba",
-          "description":"",
-          "decoderType": "tx",
-          "networkMain": true,
-          "networkTest": false,
-          "networkSTN": false,
-          "typeSearch": false,
-          "name": "BMAP",
-          "website": "https://map.sv",
-          "iconUrl": "https://iili.io/iWj0gV.png",
-          "webHook": "https://b.map.sv/tx/{tx}",
-          "hashPreview": "3201527adf80245b9363499f1329971d2d8efbd063cd17ce379f98cd2ab78f4c",
-          "voutPreview": ""
-      },
-      {
           "id": "lek0rckx",
           "description":"",
           "decoderType": "script",


### PR DESCRIPTION
This PR removes the plugin for the http://b.map.sv BMAP viewer plugin since http://b.map.sv is no longer online